### PR TITLE
Adds alternate version of demo that works with Conjur Enterprise

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
       CONJUR_AUTHN_API_KEY: 
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: demo
-      CONJUR_VERSION: 4
 
     depends_on: [ conjur ]
 
@@ -28,7 +27,6 @@ services:
       CONJUR_AUTHN_API_KEY: 
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: demo
-      CONJUR_VERSION: 4
 
     depends_on: [ conjur, helloworld ]
 

--- a/enterprise/connect
+++ b/enterprise/connect
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+consumer_id="consumer"
+
+export CONJUR_AUTHN_API_KEY=$(\
+    docker-compose run -T client host rotate_api_key \
+    --host "$consumer_id" \
+    | tr -d "\r\n")
+
+docker-compose run consumer $@

--- a/enterprise/docker-compose.yaml
+++ b/enterprise/docker-compose.yaml
@@ -1,15 +1,47 @@
 version: "3"
 services:
-  
+  helloworld:
+    image: conjur-rotation-demo-helloworld
+    environment:
+      RACK_ENV: DEMO
+      CONJUR_AUTHN_LOGIN: host/helloworld
+      CONJUR_AUTHN_API_KEY:
+      CONJUR_APPLIANCE_URL: https://conjur/api
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_CERT_FILE: /mnt/ssl/ca.pem
+      CONJUR_VERSION: 4
+    volumes:
+      - conjur-cert:/mnt/ssl
+    depends_on: [ conjur ]
+
+
+  consumer:
+    image: conjur-rotation-demo-consumer
+    environment:
+      CONJUR_AUTHN_LOGIN: host/consumer
+      CONJUR_AUTHN_API_KEY:
+      CONJUR_APPLIANCE_URL: https://conjur/api
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_CERT_FILE: /mnt/ssl/ca.pem
+      CONJUR_VERSION: 4
+    volumes:
+      - conjur-cert:/mnt/ssl
+    depends_on: [ conjur ]
+
   conjur:
     image: registry2.itci.conjur.net/conjur-appliance-cuke-master:4.9-stable
     security_opt:
       - 'seccomp=unconfined'
     ports:
       - 8443:443
+    volumes:
+      - conjur-cert:/opt/conjur/etc/ssl/
 
   client:
     image: cyberark/conjur-cli:4
     depends_on: [ conjur ]
     volumes:
       - ./cli:/root
+
+volumes:
+  conjur-cert:

--- a/enterprise/load-policy
+++ b/enterprise/load-policy
@@ -2,6 +2,5 @@
 
 set -eu
 
-docker-compose run --rm -T --entrypoint "/bin/bash" client bash -c \
-    'conjur client plugin install policy \
-    && conjur policy load --as-role group:security_admin /root/policy.yaml'
+docker-compose run --rm client plugin install policy
+docker-compose run --rm client policy load --as-group=security_admin policy.yaml

--- a/enterprise/start
+++ b/enterprise/start
@@ -9,6 +9,7 @@ docker-compose pull --quiet conjur
 # Remove containers and files created in earlier runs (if any)
 echo 'Bringing up fresh containers...'
 docker-compose down
+rm cli/.conjurrc
 
 # Start containers & wait for Conjur to be responsive
 docker-compose up -d

--- a/enterprise/start-helloworld
+++ b/enterprise/start-helloworld
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export CONJUR_AUTHN_API_KEY=$(\
+    docker-compose run --rm -T client host rotate_api_key --host helloworld \
+    | tr -d "\r\n")
+echo "rotated 'helloworld' machine identity API key"
+
+docker-compose up -d helloworld

--- a/helloworld/helloworld.rb
+++ b/helloworld/helloworld.rb
@@ -8,9 +8,13 @@ secret = SecureRandom.hex(20)
 
 conjur_username = ENV['CONJUR_AUTHN_LOGIN']
 conjur_api_key = ENV['CONJUR_AUTHN_API_KEY']
+conjur_account = ENV['CONJUR_ACCOUNT']
+conjur_cert = ENV['CONJUR_CERT_FILE']
+
+OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE.add_file conjur_cert if conjur_cert
 
 api = Conjur::API.new_from_key conjur_username, conjur_api_key
-api.resource("demo:variable:helloworld-secret").add_value secret
+api.resource("#{conjur_account}:variable:helloworld-secret").add_value secret
 
 use Rack::TokenAuth do |token, options, env|
   token == secret


### PR DESCRIPTION
#### What does this PR do?
* It expands the `enterprise/docker-compose.yml` and provides tailored versions of other scripts so that you can follow the instructions from `README.md` in the `enterprise` folder to get the same demo but with Conjur EE
* It enhances the `helloworld` app to use TLS if a cert path is provided.
