### PR TITLE
Changing os library for go to a newer version

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Build golang binary stage
-FROM golang:1.10
+FROM golang:1.12
 
 RUN go get github.com/cyberark/conjur-api-go/conjurapi
 COPY ./consumer.go .


### PR DESCRIPTION
Some go functions weren't supported by 1.10